### PR TITLE
Initial updates for 3.13.1 release

### DIFF
--- a/grab_datafiles.sh
+++ b/grab_datafiles.sh
@@ -7,59 +7,142 @@
 set -e
 
 # Download the release files
-mkdir data
+mkdir -p data
 cd data
 
+OPTIONS="-sSOL"
+
 # 3.10.1
-curl -sSOL https://github.com/sqlitebrowser/sqlitebrowser/releases/download/v3.10.1/DB.Browser.for.SQLite-3.10.1-win32.exe
-curl -sSOL https://github.com/sqlitebrowser/sqlitebrowser/releases/download/v3.10.1/DB.Browser.for.SQLite-3.10.1-win64.exe
-curl -sSOL https://github.com/sqlitebrowser/sqlitebrowser/releases/download/v3.10.1/DB.Browser.for.SQLite-3.10.1.dmg
-curl -sSOL https://github.com/sqlitebrowser/sqlitebrowser/releases/download/v3.10.1/SQLiteDatabaseBrowserPortable_3.10.1_English.paf.exe
+for file in \
+    DB.Browser.for.SQLite-3.10.1-win32.exe \
+    DB.Browser.for.SQLite-3.10.1-win64.exe \
+    DB.Browser.for.SQLite-3.10.1.dmg \
+    SQLiteDatabaseBrowserPortable_3.10.1_English.paf.exe; do
+  if [ ! -s "${file}" ]; then
+    echo
+    echo "Downloading ${file}"
+    curl "${OPTIONS}" "https://github.com/sqlitebrowser/sqlitebrowser/releases/download/v3.10.1/${file}"
+  else
+    echo " * ${file} already downloaded"
+  fi
+done
 
 # 3.11.0
-curl -sSOL https://github.com/sqlitebrowser/sqlitebrowser/releases/download/v3.11.0/DB.Browser.for.SQLite-3.11.0-win32.msi
-curl -sSOL https://github.com/sqlitebrowser/sqlitebrowser/releases/download/v3.11.0/DB.Browser.for.SQLite-3.11.0-win32.zip
-curl -sSOL https://github.com/sqlitebrowser/sqlitebrowser/releases/download/v3.11.0/DB.Browser.for.SQLite-3.11.0-win64.msi
-curl -sSOL https://github.com/sqlitebrowser/sqlitebrowser/releases/download/v3.11.0/DB.Browser.for.SQLite-3.11.0-win64.zip
-curl -sSOL https://github.com/sqlitebrowser/sqlitebrowser/releases/download/v3.11.0/DB.Browser.for.SQLite-3.11.0.dmg
+for file in \
+    DB.Browser.for.SQLite-3.11.0-win32.msi \
+    DB.Browser.for.SQLite-3.11.0-win32.zip \
+    DB.Browser.for.SQLite-3.11.0-win64.msi \
+    DB.Browser.for.SQLite-3.11.0-win64.zip \
+    DB.Browser.for.SQLite-3.11.0.dmg; do
+  if [ ! -s "${file}" ]; then
+    echo
+    echo "Downloading ${file}"
+    curl "${OPTIONS}" "https://github.com/sqlitebrowser/sqlitebrowser/releases/download/v3.11.0/${file}"
+  else
+    echo " * ${file} already downloaded"
+  fi
+done
 
 # 3.11.1
-curl -sSOL https://github.com/sqlitebrowser/sqlitebrowser/releases/download/v3.11.1/DB.Browser.for.SQLite-3.11.1-win32.msi
-curl -sSOL https://github.com/sqlitebrowser/sqlitebrowser/releases/download/v3.11.1/DB.Browser.for.SQLite-3.11.1-win32.zip
-curl -sSOL https://github.com/sqlitebrowser/sqlitebrowser/releases/download/v3.11.1/DB.Browser.for.SQLite-3.11.1-win64.msi
-curl -sSOL https://github.com/sqlitebrowser/sqlitebrowser/releases/download/v3.11.1/DB.Browser.for.SQLite-3.11.1-win64.zip
-curl -sSOL https://github.com/sqlitebrowser/sqlitebrowser/releases/download/v3.11.1/DB.Browser.for.SQLite-3.11.1v2.dmg
+for file in \
+    DB.Browser.for.SQLite-3.11.1-win32.msi \
+    DB.Browser.for.SQLite-3.11.1-win32.zip \
+    DB.Browser.for.SQLite-3.11.1-win64.msi \
+    DB.Browser.for.SQLite-3.11.1-win64.zip \
+    DB.Browser.for.SQLite-3.11.1v2.dmg; do
+  if [ ! -s "${file}" ]; then
+    echo
+    echo "Downloading ${file}"
+    curl "${OPTIONS}" "https://github.com/sqlitebrowser/sqlitebrowser/releases/download/v3.11.1/${file}"
+  else
+    echo " * ${file} already downloaded"
+  fi
+done
 
 # 3.11.2
-curl -sSOL https://github.com/sqlitebrowser/sqlitebrowser/releases/download/v3.11.2/DB.Browser.for.SQLite-3.11.2-win32.msi
-curl -sSOL https://github.com/sqlitebrowser/sqlitebrowser/releases/download/v3.11.2/DB.Browser.for.SQLite-3.11.2-win32.zip
-curl -sSOL https://github.com/sqlitebrowser/sqlitebrowser/releases/download/v3.11.2/DB.Browser.for.SQLite-3.11.2-win64.msi
-curl -sSOL https://github.com/sqlitebrowser/sqlitebrowser/releases/download/v3.11.2/DB.Browser.for.SQLite-3.11.2-win64.zip
-curl -sSOL https://github.com/sqlitebrowser/sqlitebrowser/releases/download/v3.11.2/DB.Browser.for.SQLite-3.11.2.dmg
-curl -sSOL https://github.com/sqlitebrowser/sqlitebrowser/releases/download/v3.11.2/SQLiteDatabaseBrowserPortable_3.11.2_Rev_2_English.paf.exe
+for file in \
+    DB.Browser.for.SQLite-3.11.2-win32.msi \
+    DB.Browser.for.SQLite-3.11.2-win32.zip \
+    DB.Browser.for.SQLite-3.11.2-win64.msi \
+    DB.Browser.for.SQLite-3.11.2-win64.zip \
+    DB.Browser.for.SQLite-3.11.2.dmg \
+    SQLiteDatabaseBrowserPortable_3.11.2_Rev_2_English.paf.exe; do
+  if [ ! -s "${file}" ]; then
+    echo
+    echo "Downloading ${file}"
+    curl "${OPTIONS}" "https://github.com/sqlitebrowser/sqlitebrowser/releases/download/v3.11.2/${file}"
+  else
+    echo " * ${file} already downloaded"
+  fi
+done
 
 # 3.12.0
-curl -sSOL https://github.com/sqlitebrowser/sqlitebrowser/releases/download/v3.12.0/DB.Browser.for.SQLite-3.12.0-win32.msi
-curl -sSOL https://github.com/sqlitebrowser/sqlitebrowser/releases/download/v3.12.0/DB.Browser.for.SQLite-3.12.0-win32.zip
-curl -sSOL https://github.com/sqlitebrowser/sqlitebrowser/releases/download/v3.12.0/DB.Browser.for.SQLite-3.12.0-win64.msi
-curl -sSOL https://github.com/sqlitebrowser/sqlitebrowser/releases/download/v3.12.0/DB.Browser.for.SQLite-3.12.0-win64.zip
-curl -sSOL https://github.com/sqlitebrowser/sqlitebrowser/releases/download/v3.12.0/DB.Browser.for.SQLite-3.12.0.dmg
-curl -sSOL https://github.com/sqlitebrowser/sqlitebrowser/releases/download/v3.12.0/SQLiteDatabaseBrowserPortable_3.12.0_English.paf.exe
+for file in \
+    DB.Browser.for.SQLite-3.12.0-win32.msi \
+    DB.Browser.for.SQLite-3.12.0-win32.zip \
+    DB.Browser.for.SQLite-3.12.0-win64.msi \
+    DB.Browser.for.SQLite-3.12.0-win64.zip \
+    DB.Browser.for.SQLite-3.12.0.dmg \
+    SQLiteDatabaseBrowserPortable_3.12.0_English.paf.exe; do
+  if [ ! -s "${file}" ]; then
+    echo
+    echo "Downloading ${file}"
+    curl "${OPTIONS}" "https://github.com/sqlitebrowser/sqlitebrowser/releases/download/v3.12.0/${file}"
+  else
+    echo " * ${file} already downloaded"
+  fi
+done
 
 # 3.12.2
-curl -sSOL https://github.com/sqlitebrowser/sqlitebrowser/releases/download/v3.12.2/DB.Browser.for.SQLite-3.12.2-win32.msi
-curl -sSOL https://github.com/sqlitebrowser/sqlitebrowser/releases/download/v3.12.2/DB.Browser.for.SQLite-3.12.2-win32.zip
-curl -sSOL https://github.com/sqlitebrowser/sqlitebrowser/releases/download/v3.12.2/DB.Browser.for.SQLite-3.12.2-win64.msi
-curl -sSOL https://github.com/sqlitebrowser/sqlitebrowser/releases/download/v3.12.2/DB.Browser.for.SQLite-3.12.2-win64.zip
-curl -sSOL https://github.com/sqlitebrowser/sqlitebrowser/releases/download/v3.12.2/DB.Browser.for.SQLite-3.12.2.dmg
-curl -sSOL https://github.com/sqlitebrowser/sqlitebrowser/releases/download/v3.12.2/DB.Browser.for.SQLite-arm64-3.12.2.dmg
-curl -sSOL https://github.com/sqlitebrowser/sqlitebrowser/releases/download/v3.12.2/DB_Browser_for_SQLite-v3.12.2-x86_64.AppImage
-curl -sSOL https://github.com/sqlitebrowser/sqlitebrowser/releases/download/v3.12.2/SQLiteDatabaseBrowserPortable_3.12.2_English.paf.exe
+for file in \
+    DB.Browser.for.SQLite-3.12.2-win32.msi \
+    DB.Browser.for.SQLite-3.12.2-win32.zip \
+    DB.Browser.for.SQLite-3.12.2-win64.msi \
+    DB.Browser.for.SQLite-3.12.2-win64.zip \
+    DB.Browser.for.SQLite-3.12.2.dmg \
+    DB.Browser.for.SQLite-arm64-3.12.2.dmg \
+    DB_Browser_for_SQLite-v3.12.2-x86_64.AppImage \
+    SQLiteDatabaseBrowserPortable_3.12.2_English.paf.exe; do
+  if [ ! -s "${file}" ]; then
+    echo
+    echo "Downloading ${file}"
+    curl "${OPTIONS}" "https://github.com/sqlitebrowser/sqlitebrowser/releases/download/v3.12.2/${file}"
+  else
+    echo " * ${file} already downloaded"
+  fi
+done
 
 # 3.13.0
-curl -sSOL https://github.com/sqlitebrowser/sqlitebrowser/releases/download/v3.13.0/DB.Browser.for.SQLite-v3.13.0.dmg
-curl -sSOL https://github.com/sqlitebrowser/sqlitebrowser/releases/download/v3.13.0/DB.Browser.for.SQLite-v3.13.0-win32.msi
-curl -sSOL https://github.com/sqlitebrowser/sqlitebrowser/releases/download/v3.13.0/DB.Browser.for.SQLite-v3.13.0-win32.zip
-curl -sSOL https://github.com/sqlitebrowser/sqlitebrowser/releases/download/v3.13.0/DB.Browser.for.SQLite-v3.13.0-win64.msi
-curl -sSOL https://github.com/sqlitebrowser/sqlitebrowser/releases/download/v3.13.0/DB.Browser.for.SQLite-v3.13.0-win64.zip
-curl -sSOL https://github.com/sqlitebrowser/sqlitebrowser/releases/download/v3.13.0/DB.Browser.for.SQLite-v3.13.0-x86.64.AppImage
+for file in \
+    DB.Browser.for.SQLite-v3.13.0.dmg \
+    DB.Browser.for.SQLite-v3.13.0-win32.msi \
+    DB.Browser.for.SQLite-v3.13.0-win32.zip \
+    DB.Browser.for.SQLite-v3.13.0-win64.msi \
+    DB.Browser.for.SQLite-v3.13.0-win64.zip \
+    DB.Browser.for.SQLite-v3.13.0-x86.64.AppImage; do
+  if [ ! -s "${file}" ]; then
+    echo
+    echo "Downloading ${file}"
+    curl "${OPTIONS}" "https://github.com/sqlitebrowser/sqlitebrowser/releases/download/v3.13.0/${file}"
+  else
+    echo " * ${file} already downloaded"
+  fi
+done
+
+# TODO: Uncomment this once the GitHub Release is available
+## 3.13.1
+#for file in \
+#    DB.Browser.for.SQLite-v3.13.1.dmg \
+#    DB.Browser.for.SQLite-v3.13.1-win32.msi \
+#    DB.Browser.for.SQLite-v3.13.1-win32.zip \
+#    DB.Browser.for.SQLite-v3.13.1-win64.msi \
+#    DB.Browser.for.SQLite-v3.13.1-win64.zip \
+#    DB.Browser.for.SQLite-v3.13.1-x86.64.AppImage; do
+#  if [ ! -s "${file}" ]; then
+#    echo
+#    echo "Downloading ${file}"
+#    curl "${OPTIONS}" "https://github.com/sqlitebrowser/sqlitebrowser/releases/download/v3.13.1/${file}"
+#  else
+#    echo " * ${file} already downloaded"
+#  fi
+#done

--- a/grab_datafiles.sh
+++ b/grab_datafiles.sh
@@ -129,20 +129,19 @@ for file in \
   fi
 done
 
-# TODO: Uncomment this once the GitHub Release is available
-## 3.13.1
-#for file in \
-#    DB.Browser.for.SQLite-v3.13.1.dmg \
-#    DB.Browser.for.SQLite-v3.13.1-win32.msi \
-#    DB.Browser.for.SQLite-v3.13.1-win32.zip \
-#    DB.Browser.for.SQLite-v3.13.1-win64.msi \
-#    DB.Browser.for.SQLite-v3.13.1-win64.zip \
-#    DB.Browser.for.SQLite-v3.13.1-x86.64.AppImage; do
-#  if [ ! -s "${file}" ]; then
-#    echo
-#    echo "Downloading ${file}"
-#    curl "${OPTIONS}" "https://github.com/sqlitebrowser/sqlitebrowser/releases/download/v3.13.1/${file}"
-#  else
-#    echo " * ${file} already downloaded"
-#  fi
-#done
+# 3.13.1
+for file in \
+    DB.Browser.for.SQLite-v3.13.1.dmg \
+    DB.Browser.for.SQLite-v3.13.1-win32.msi \
+    DB.Browser.for.SQLite-v3.13.1-win32.zip \
+    DB.Browser.for.SQLite-v3.13.1-win64.msi \
+    DB.Browser.for.SQLite-v3.13.1-win64.zip \
+    DB.Browser.for.SQLite-v3.13.1-x86.64.AppImage; do
+  if [ ! -s "${file}" ]; then
+    echo
+    echo "Downloading ${file}"
+    curl "${OPTIONS}" "https://github.com/sqlitebrowser/sqlitebrowser/releases/download/v3.13.1/${file}"
+  else
+    echo " * ${file} already downloaded"
+  fi
+done

--- a/main.go
+++ b/main.go
@@ -38,8 +38,7 @@ var (
 	// bother any more as that's probably not important
 	timeStamps = map[string]time.Time{
 		// SHA256 checksums
-		// TODO: Update timestamp when 3.13.1 is released
-		"SHA256SUMS.txt": time.Date(2024, time.July, 22, 12, 41, 37, 0, time.UTC),
+		"SHA256SUMS.txt": time.Date(2024, time.October, 16, 07, 48, 52, 0, time.UTC),
 
 		// *** 3.10.1 release ***
 		"DB.Browser.for.SQLite-3.10.1-win32.exe":               time.Date(2017, time.September, 20, 14, 59, 44, 0, time.UTC),

--- a/main.go
+++ b/main.go
@@ -38,6 +38,7 @@ var (
 	// bother any more as that's probably not important
 	timeStamps = map[string]time.Time{
 		// SHA256 checksums
+		// TODO: Update timestamp when 3.13.1 is released
 		"SHA256SUMS.txt": time.Date(2024, time.July, 22, 12, 41, 37, 0, time.UTC),
 
 		// *** 3.10.1 release ***
@@ -95,6 +96,14 @@ var (
 		"DB.Browser.for.SQLite-v3.13.0-win64.msi":       time.Date(2024, time.July, 22, 12, 41, 37, 0, time.UTC),
 		"DB.Browser.for.SQLite-v3.13.0-win64.zip":       time.Date(2024, time.July, 22, 12, 41, 37, 0, time.UTC),
 		"DB.Browser.for.SQLite-v3.13.0-x86.64.AppImage": time.Date(2024, time.July, 22, 12, 41, 37, 0, time.UTC),
+
+		// *** 3.13.1 release ***
+		"DB.Browser.for.SQLite-v3.13.1.dmg":             time.Date(2024, time.October, 16, 07, 48, 52, 0, time.UTC),
+		"DB.Browser.for.SQLite-v3.13.1-win32.msi":       time.Date(2024, time.October, 16, 07, 48, 52, 0, time.UTC),
+		"DB.Browser.for.SQLite-v3.13.1-win32.zip":       time.Date(2024, time.October, 16, 07, 48, 52, 0, time.UTC),
+		"DB.Browser.for.SQLite-v3.13.1-win64.msi":       time.Date(2024, time.October, 16, 07, 48, 52, 0, time.UTC),
+		"DB.Browser.for.SQLite-v3.13.1-win64.zip":       time.Date(2024, time.October, 16, 07, 48, 52, 0, time.UTC),
+		"DB.Browser.for.SQLite-v3.13.1-x86.64.AppImage": time.Date(2024, time.October, 16, 07, 48, 52, 0, time.UTC),
 	}
 
 	// RecordDownloadsLocation controls where downloads are recorded
@@ -196,7 +205,7 @@ func connectDatabase() {
 
 // currentReleaseHandler serves the "current release" information to users
 func currentReleaseHandler(c *gin.Context) {
-	resp := "3.13.0\nhttps://sqlitebrowser.org/blog/version-3-13-0-released\n"
+	resp := "3.13.1\nhttps://sqlitebrowser.org/blog/version-3-13-1-released\n"
 	c.String(200, resp)
 }
 
@@ -233,8 +242,8 @@ func fileHandler(c *gin.Context) {
 
 	// Send the file contents
 	// We use http.ServeContent() here as it allows setting the desired "last modified" timestamp.  The other functions
-	// we could have used instead - c.File() and http.ServeFile() - don't allow this.  Those ones just read the date of
-	// the file on disk, whereas we want to use timestamp entries matching the GitHub release files
+	// we could have used instead - c.File() and http.ServeFile() - don't allow this.  Those just read the date of the
+	// file on disk, whereas we want to use timestamp entries matching the GitHub release files
 	z, err := os.Open(fullPath)
 	if err != nil {
 		fmt.Fprintf(c.Writer, "Internal server error")

--- a/main_test.go
+++ b/main_test.go
@@ -20,7 +20,7 @@ var (
 	}{
 		"currentrelease": {
 			url:          "/currentrelease",
-			expectedData: "3.13.0\nhttps://sqlitebrowser.org/blog/version-3-13-0-released\n",
+			expectedData: "3.13.1\nhttps://sqlitebrowser.org/blog/version-3-13-1-released\n",
 			expectedType: "string",
 		},
 		"icon": {
@@ -30,11 +30,44 @@ var (
 		},
 		"indexpage": {
 			url:          "/",
-			expectedData: "81d7c94b13324f3f739429799ea1740898411f16916659987378ccf1ece0d2b1",
+			expectedData: "28e72d910d953f25d0a6a24a70b8aceff30d3422a51d6e1fef3a0702c59da618",
 			expectedType: "sha256",
 		},
 
 		// DB4S files
+
+		//// TODO: Uncomment this when 3.13.1 release is public
+		//// 3.13.1
+		//"DB.Browser.for.SQLite-v3.13.1-win32.msi": {
+		//	url:          "/DB.Browser.for.SQLite-v3.13.1-win32.msi",
+		//	expectedData: "e0b9f86d3da4d8d800e144295487e43de306c1bd27f14dccfe41e904736f25f7",
+		//	expectedType: "sha256",
+		//},
+		//"DB.Browser.for.SQLite-v3.13.1-win32.zip": {
+		//	url:          "/DB.Browser.for.SQLite-v3.13.1-win32.zip",
+		//	expectedData: "917ad2fa8d36e3bfa3fc85b11a34a8c18d189fbc2289f5a0d3bf41de8a288edc",
+		//	expectedType: "sha256",
+		//},
+		//"DB.Browser.for.SQLite-v3.13.1-win64.msi": {
+		//	url:          "/DB.Browser.for.SQLite-v3.13.1-win64.msi",
+		//	expectedData: "d023d54b3a5db10c7e896089bb3dbe6e7f4bc4eaa9bbecb34ca414be5970f688",
+		//	expectedType: "sha256",
+		//},
+		//"DB.Browser.for.SQLite-v3.13.1-win64.zip": {
+		//	url:          "/DB.Browser.for.SQLite-v3.13.1-win64.zip",
+		//	expectedData: "22375e275ec42d96de1d3b8e9ea4ed86d2a3505c4d0ffcbd1af67aa4003e5e4d",
+		//	expectedType: "sha256",
+		//},
+		//"DB.Browser.for.SQLite-v3.13.1-x86.64.AppImage": {
+		//	url:          "/DB.Browser.for.SQLite-v3.13.1-x86.64.AppImage",
+		//	expectedData: "d6563c5c211a73192da96e3bb11a3bf83a2f3164aa4db83482c0aecf8b751b77",
+		//	expectedType: "sha256",
+		//},
+		//"DB.Browser.for.SQLite-v3.13.1.dmg": {
+		//	url:          "/DB.Browser.for.SQLite-v3.13.1.dmg",
+		//	expectedData: "a641cfbfcc2ce609f07de44a35134dab53485ecc18e6d9afa297b514d74bd75e",
+		//	expectedType: "sha256",
+		//},
 
 		// 3.13.0
 		"DB.Browser.for.SQLite-v3.13.0-win32.msi": {

--- a/main_test.go
+++ b/main_test.go
@@ -36,38 +36,37 @@ var (
 
 		// DB4S files
 
-		//// TODO: Uncomment this when 3.13.1 release is public
-		//// 3.13.1
-		//"DB.Browser.for.SQLite-v3.13.1-win32.msi": {
-		//	url:          "/DB.Browser.for.SQLite-v3.13.1-win32.msi",
-		//	expectedData: "e0b9f86d3da4d8d800e144295487e43de306c1bd27f14dccfe41e904736f25f7",
-		//	expectedType: "sha256",
-		//},
-		//"DB.Browser.for.SQLite-v3.13.1-win32.zip": {
-		//	url:          "/DB.Browser.for.SQLite-v3.13.1-win32.zip",
-		//	expectedData: "917ad2fa8d36e3bfa3fc85b11a34a8c18d189fbc2289f5a0d3bf41de8a288edc",
-		//	expectedType: "sha256",
-		//},
-		//"DB.Browser.for.SQLite-v3.13.1-win64.msi": {
-		//	url:          "/DB.Browser.for.SQLite-v3.13.1-win64.msi",
-		//	expectedData: "d023d54b3a5db10c7e896089bb3dbe6e7f4bc4eaa9bbecb34ca414be5970f688",
-		//	expectedType: "sha256",
-		//},
-		//"DB.Browser.for.SQLite-v3.13.1-win64.zip": {
-		//	url:          "/DB.Browser.for.SQLite-v3.13.1-win64.zip",
-		//	expectedData: "22375e275ec42d96de1d3b8e9ea4ed86d2a3505c4d0ffcbd1af67aa4003e5e4d",
-		//	expectedType: "sha256",
-		//},
-		//"DB.Browser.for.SQLite-v3.13.1-x86.64.AppImage": {
-		//	url:          "/DB.Browser.for.SQLite-v3.13.1-x86.64.AppImage",
-		//	expectedData: "d6563c5c211a73192da96e3bb11a3bf83a2f3164aa4db83482c0aecf8b751b77",
-		//	expectedType: "sha256",
-		//},
-		//"DB.Browser.for.SQLite-v3.13.1.dmg": {
-		//	url:          "/DB.Browser.for.SQLite-v3.13.1.dmg",
-		//	expectedData: "a641cfbfcc2ce609f07de44a35134dab53485ecc18e6d9afa297b514d74bd75e",
-		//	expectedType: "sha256",
-		//},
+		// 3.13.1
+		"DB.Browser.for.SQLite-v3.13.1-win32.msi": {
+			url:          "/DB.Browser.for.SQLite-v3.13.1-win32.msi",
+			expectedData: "e0b9f86d3da4d8d800e144295487e43de306c1bd27f14dccfe41e904736f25f7",
+			expectedType: "sha256",
+		},
+		"DB.Browser.for.SQLite-v3.13.1-win32.zip": {
+			url:          "/DB.Browser.for.SQLite-v3.13.1-win32.zip",
+			expectedData: "917ad2fa8d36e3bfa3fc85b11a34a8c18d189fbc2289f5a0d3bf41de8a288edc",
+			expectedType: "sha256",
+		},
+		"DB.Browser.for.SQLite-v3.13.1-win64.msi": {
+			url:          "/DB.Browser.for.SQLite-v3.13.1-win64.msi",
+			expectedData: "d023d54b3a5db10c7e896089bb3dbe6e7f4bc4eaa9bbecb34ca414be5970f688",
+			expectedType: "sha256",
+		},
+		"DB.Browser.for.SQLite-v3.13.1-win64.zip": {
+			url:          "/DB.Browser.for.SQLite-v3.13.1-win64.zip",
+			expectedData: "22375e275ec42d96de1d3b8e9ea4ed86d2a3505c4d0ffcbd1af67aa4003e5e4d",
+			expectedType: "sha256",
+		},
+		"DB.Browser.for.SQLite-v3.13.1-x86.64.AppImage": {
+			url:          "/DB.Browser.for.SQLite-v3.13.1-x86.64.AppImage",
+			expectedData: "d6563c5c211a73192da96e3bb11a3bf83a2f3164aa4db83482c0aecf8b751b77",
+			expectedType: "sha256",
+		},
+		"DB.Browser.for.SQLite-v3.13.1.dmg": {
+			url:          "/DB.Browser.for.SQLite-v3.13.1.dmg",
+			expectedData: "a641cfbfcc2ce609f07de44a35134dab53485ecc18e6d9afa297b514d74bd75e",
+			expectedType: "sha256",
+		},
 
 		// 3.13.0
 		"DB.Browser.for.SQLite-v3.13.0-win32.msi": {

--- a/template.html
+++ b/template.html
@@ -19,6 +19,18 @@ Available downloads:
 </p>
 
 <p>
+    <h4>version 3.13.1</h4>
+    <ul>
+        <li><a href="/DB.Browser.for.SQLite-v3.13.1-win32.msi">DB.Browser.for.SQLite-v3.13.1-win32.msi</a> - For Windows 32-bit</li>
+        <li><a href="/DB.Browser.for.SQLite-v3.13.1-win32.zip">DB.Browser.for.SQLite-v3.13.1-win32.zip</a> - For Windows 32-bit</li>
+        <li><a href="/DB.Browser.for.SQLite-v3.13.1-win64.msi">DB.Browser.for.SQLite-v3.13.1-win64.msi</a> - For Windows 64-bit</li>
+        <li><a href="/DB.Browser.for.SQLite-v3.13.1-win64.zip">DB.Browser.for.SQLite-v3.13.1-win64.zip</a> - For Windows 64-bit</li>
+        <li><a href="/DB.Browser.for.SQLite-v3.13.1.dmg">DB.Browser.for.SQLite-v3.13.1.dmg</a> - For macOS (both <b>Apple Silicon</b> and <b>Intel</b>)</li>
+        <li><a href="/DB.Browser.for.SQLite-v3.13.1-x86.64.AppImage">DB.Browser.for.SQLite-v3.13.1-x86.64.AppImage</a> - AppImage for Linux</li>
+    </ul>
+</p>
+
+<p>
     <h4>version 3.13.0</h4>
     <ul>
         <li><a href="/DB.Browser.for.SQLite-v3.13.0-win32.msi">DB.Browser.for.SQLite-v3.13.0-win32.msi</a> - For Windows 32-bit</li>


### PR DESCRIPTION
Initial update for 3.13.1 release.

The CI tests can't be enabled until the new release is public on GitHub, as the CI tests download the files from there. :wink: